### PR TITLE
Fixup Shared folder for n8n v2

### DIFF
--- a/base/docker-compose.yaml
+++ b/base/docker-compose.yaml
@@ -92,7 +92,6 @@ services:
     volumes:
       - n8n_storage:/home/node/.n8n
       - ./n8n/demo-data:/demo-data
-      - ./shared:/data/shared
     depends_on:
       postgres:
         condition: service_healthy

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -28,6 +28,8 @@ services:
     env_file:
       - path: n8n.env
         required: true
+    volumes:
+      - ./shared:/home/node/.n8n-files
   qdrant:
     extends:
       file: ../base/docker-compose.yaml

--- a/dev/shared/.gitignore
+++ b/dev/shared/.gitignore
@@ -1,0 +1,2 @@
+# do not track any n8n output files
+*


### PR DESCRIPTION
- Move shared container folder to new n8n output dir
  - Match n8n 2.0 default where files can be written to

See [n8n 2.0 Breaking Changes](https://docs.n8n.io/2-0-breaking-changes/#set-default-value-for-n8n_restrict_file_access_to)


Fixes #3 