### PR TITLE
Switch vLLM, for CUDA 13 support

### DIFF
--- a/base/medgemma/docker-compose.yaml
+++ b/base/medgemma/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   medgemma:
-    image: vllm/vllm-openai:latest
+    image: nvcr.io/nvidia/vllm:26.02-py3
     gpus: all
 
     volumes:
@@ -10,11 +10,16 @@ services:
       - 8000
     environment:
       HUGGING_FACE_HUB_TOKEN: ${HUGGING_FACE_HUB_TOKEN}
-    command: >
-      --dtype bfloat16
-      --max-model-len 8192
-      --gpu-memory-utilization 0.90
-      google/medgemma-1.5-4b-it
+    command:
+      - vllm
+      - serve
+      - google/medgemma-1.5-4b-it
+      - --dtype
+      - bfloat16
+      - --max-model-len
+      - "8192"
+      - --gpu-memory-utilization
+      - "0.90"
 
 volumes:
   hf-cache:

--- a/base/medgemma/docker-compose.yaml
+++ b/base/medgemma/docker-compose.yaml
@@ -2,6 +2,8 @@ services:
   medgemma:
     image: nvcr.io/nvidia/vllm:26.02-py3
     gpus: all
+    # increase /dev/shm shared memory size from default 64MB
+    shm_size: 8g
 
     volumes:
       - hf-cache:/root/.huggingface


### PR DESCRIPTION
- Switch to nvidia-maintained [docker image](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/vllm?version=26.02-py3) of vLLM, for CUDA 13 support
- [vLLM Release 25.09](https://docs.nvidia.com/deeplearning/frameworks/vllm-release-notes/rel-25-09.html#)
