### PR TITLE
Use Custom n8n Task Runner Image

### DIFF
--- a/base/task-runners/docker-compose.yaml
+++ b/base/task-runners/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   task-runners:
-    image: n8nio/runners:${RUNNERS_IMAGE_TAG:-2.29.2}
+    image: ghcr.io/uwcirg/n8n-builder:${RUNNERS_IMAGE_TAG:-runner-main}
     restart: unless-stopped
     volumes:
       - ./n8n-task-runners.json:/etc/n8n-task-runners.json:ro

--- a/base/task-runners/n8n-task-runners.json
+++ b/base/task-runners/n8n-task-runners.json
@@ -49,7 +49,7 @@
       ],
       "env-overrides": {
         "N8N_RUNNERS_STDLIB_ALLOW": "json,math,datetime,random,re,statistics,decimal,base64,io",
-        "N8N_RUNNERS_EXTERNAL_ALLOW": ""
+        "N8N_RUNNERS_EXTERNAL_ALLOW": "pypdfium2,pillow"
       }
     }
   ]


### PR DESCRIPTION
- Switch to custom n8n task runner image
- Add custom dependencies to allowlist

See uwcirg/n8n-builder/issues/3, uwcirg/n8n-builder/pull/5